### PR TITLE
[calibration] Add check for existing rospy init

### DIFF
--- a/src/agimus_demos/calibration/play_path.py
+++ b/src/agimus_demos/calibration/play_path.py
@@ -112,7 +112,8 @@ class CalibrationControl (object):
         self.rosJointStates = None
         self.jointNames = None
         self.pathId = 0
-        rospy.init_node ('calibration_control')
+        if not rospy.core.is_initialized():
+            rospy.init_node ('calibration_control')
         self.tfBuffer = tf2_ros.Buffer(rospy.Duration (1,0))
         self.tf2Listener = tf2_ros.TransformListener(self.tfBuffer)
         self.pubStartPath = rospy.Publisher ("/agimus/start_path", UInt32,


### PR DESCRIPTION
Check if rospy.init_node has been called previously to avoid calling it twice when launching the teach widget( one in tool_hpp.py in ur10/pointing module and one in play_path.py)